### PR TITLE
Fix ingredient amount column and add category field

### DIFF
--- a/weekly-dish/app/api/recipes/route.ts
+++ b/weekly-dish/app/api/recipes/route.ts
@@ -14,3 +14,59 @@ export async function GET() {
 
   return NextResponse.json({ recipes });
 }
+
+export async function POST(request: Request) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "未認証です" }, { status: 401 });
+  }
+
+  const { title, type, category, ingredients, steps } = await request.json();
+
+  const { data: recipe, error } = await supabase
+    .from("recipes")
+    .insert({ title, type, category })
+    .select("id")
+    .single();
+
+  if (error || !recipe) {
+    return NextResponse.json(
+      { error: error?.message || "レシピ登録に失敗しました" },
+      { status: 500 },
+    );
+  }
+
+  if (Array.isArray(ingredients) && ingredients.length > 0) {
+    const ingredientData = ingredients.map((ing: any) => ({
+      recipe_id: recipe.id,
+      name: ing.name,
+      amount_text: ing.amount,
+    }));
+    const { error: ingError } = await supabase
+      .from("ingredients")
+      .insert(ingredientData);
+    if (ingError) {
+      return NextResponse.json({ error: ingError.message }, { status: 500 });
+    }
+  }
+
+  if (Array.isArray(steps) && steps.length > 0) {
+    const stepData = steps.map((step: any, idx: number) => ({
+      recipe_id: recipe.id,
+      description: step.description,
+      step_number: idx + 1,
+    }));
+    const { error: stepError } = await supabase
+      .from("steps")
+      .insert(stepData);
+    if (stepError) {
+      return NextResponse.json({ error: stepError.message }, { status: 500 });
+    }
+  }
+
+  return NextResponse.json({ id: recipe.id });
+}

--- a/weekly-dish/app/header.tsx
+++ b/weekly-dish/app/header.tsx
@@ -79,6 +79,12 @@ export default function Header() {
             >
               <span>レシピ一覧</span>
             </Link>
+            <Link
+              href="/recipes/new"
+              className="flex items-center space-x-1 hover:text-white transition"
+            >
+              <span>レシピ登録</span>
+            </Link>
             {isSignedIn && (
               <Link href="/sign-out" className="text-white ml-4">
                 Sign Out
@@ -121,6 +127,13 @@ export default function Header() {
             onClick={() => setMenuOpen(false)}
           >
             <span>レシピ一覧</span>
+          </Link>
+          <Link
+            href="/recipes/new"
+            className="flex items-center space-x-2"
+            onClick={() => setMenuOpen(false)}
+          >
+            <span>レシピ登録</span>
           </Link>
           {isSignedIn && (
             <Link

--- a/weekly-dish/app/recipes/new/page.tsx
+++ b/weekly-dish/app/recipes/new/page.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import { useState } from "react";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+
+const categories = [
+  { value: "japanese", label: "和食" },
+  { value: "western", label: "洋食" },
+  { value: "chinese", label: "中華" },
+  { value: "other", label: "その他" },
+];
+
+interface Ingredient {
+  name: string;
+  amount: string;
+}
+
+interface Step {
+  description: string;
+}
+
+export default function RecipeNewPage() {
+  const [title, setTitle] = useState("");
+  const [type, setType] = useState<"main" | "side">("main");
+  const [category, setCategory] = useState("japanese");
+  const [ingredients, setIngredients] = useState<Ingredient[]>([
+    { name: "", amount: "" },
+  ]);
+  const [steps, setSteps] = useState<Step[]>([{ description: "" }]);
+  const [message, setMessage] = useState("");
+
+  const handleAddIngredient = () =>
+    setIngredients([...ingredients, { name: "", amount: "" }]);
+  const handleAddStep = () => setSteps([...steps, { description: "" }]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setMessage("");
+    const res = await fetch("/api/recipes", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ title, type, category, ingredients, steps }),
+    });
+    const data = await res.json();
+    if (res.ok) {
+      setMessage("レシピを登録しました");
+      setTitle("");
+      setType("main");
+      setCategory("japanese");
+      setIngredients([{ name: "", amount: "" }]);
+      setSteps([{ description: "" }]);
+    } else {
+      setMessage(data.error || "登録に失敗しました");
+    }
+  };
+
+  const updateIngredient = (
+    index: number,
+    field: keyof Ingredient,
+    value: string,
+  ) => {
+    const newArr = [...ingredients];
+    newArr[index][field] = value;
+    setIngredients(newArr);
+  };
+
+  const updateStep = (index: number, value: string) => {
+    const newArr = [...steps];
+    newArr[index].description = value;
+    setSteps(newArr);
+  };
+
+  return (
+    <div className="max-w-3xl mx-auto p-6 bg-white rounded-xl shadow-lg mt-8">
+      <h1 className="text-3xl font-extrabold mb-6 text-orange-600 text-center">
+        レシピ登録
+      </h1>
+      {message && (
+        <p className="mb-4 text-center text-green-600 font-semibold">
+          {message}
+        </p>
+      )}
+      <form onSubmit={handleSubmit} className="space-y-6">
+        <div>
+          <Label htmlFor="title">レシピ名</Label>
+          <Input
+            id="title"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            required
+          />
+        </div>
+        <div>
+          <Label>種類</Label>
+          <div className="flex gap-4 mt-1">
+            <label className="flex items-center gap-1">
+              <input
+                type="radio"
+                name="type"
+                value="main"
+                checked={type === "main"}
+                onChange={() => setType("main")}
+              />
+              主菜
+            </label>
+            <label className="flex items-center gap-1">
+              <input
+                type="radio"
+                name="type"
+                value="side"
+                checked={type === "side"}
+                onChange={() => setType("side")}
+              />
+              副菜
+            </label>
+          </div>
+        </div>
+        <div>
+          <Label>カテゴリー</Label>
+          <select
+            className="mt-1 border rounded p-2"
+            value={category}
+            onChange={(e) => setCategory(e.target.value)}
+          >
+            {categories.map((c) => (
+              <option key={c.value} value={c.value}>
+                {c.label}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <Label>材料</Label>
+          {ingredients.map((ing, idx) => (
+            <div key={idx} className="flex gap-2 mt-2">
+              <Input
+                placeholder="名前"
+                value={ing.name}
+                onChange={(e) => updateIngredient(idx, "name", e.target.value)}
+                className="flex-1"
+              />
+              <Input
+                placeholder="量"
+                value={ing.amount}
+                onChange={(e) => updateIngredient(idx, "amount", e.target.value)}
+                className="flex-1"
+              />
+            </div>
+          ))}
+          <Button type="button" onClick={handleAddIngredient} className="mt-2">
+            材料追加
+          </Button>
+        </div>
+        <div>
+          <Label>手順</Label>
+          {steps.map((step, idx) => (
+            <div key={idx} className="mt-2">
+              <Input
+                placeholder={`手順${idx + 1}`}
+                value={step.description}
+                onChange={(e) => updateStep(idx, e.target.value)}
+              />
+            </div>
+          ))}
+          <Button type="button" onClick={handleAddStep} className="mt-2">
+            手順追加
+          </Button>
+        </div>
+        <Button type="submit" className="mt-4">
+          登録
+        </Button>
+      </form>
+    </div>
+  );
+}

--- a/weekly-dish/components/recipes/RecipeDetailModal.tsx
+++ b/weekly-dish/components/recipes/RecipeDetailModal.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 interface Ingredient {
   id: string;
   name: string;
-  quantity: string;
+  amount_text: string | null;
 }
 interface Step {
   id: string;
@@ -94,7 +94,7 @@ export default function RecipeDetailModal({
                 >
                   <span className="inline-block w-2 h-2 rounded-full bg-blue-400 mr-2"></span>
                   <span className="font-medium">{ing.name}</span>
-                  <span className="text-sm text-gray-500">{ing.quantity}</span>
+                  <span className="text-sm text-gray-500">{ing.amount_text}</span>
                 </li>
               ))}
             </ul>


### PR DESCRIPTION
## Summary
- add category select field on recipe registration page
- store ingredient amounts as text using `amount_text`
- display ingredient `amount_text` in recipe detail modal
- update recipe categories to 和食/洋食/中華 など

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684c3aa6c960832fb9d4cc59614b8c38